### PR TITLE
Update R130_Jan-w33p13m63-71.krn

### DIFF
--- a/kern/R130_Jan-w33p13m63-71.krn
+++ b/kern/R130_Jan-w33p13m63-71.krn
@@ -1,4 +1,13 @@
-!!!COM: Leoš [Leo Eugen] Janáček
+!!!COM: Giovannelli, Ruggiero
+!!!CDT: ~1560-1625/01/07
+!!!OTL: Non è questa la mano
+!!!PTL: Fiori musicali, libro secondo
+!!!PPP: Venice
+!!!PPR: Vincenzi & Amadino
+!!!PDT: 1588
+!!!PUB-format: anthology
+!!!AGN: Madrigal
+!!!SCT: Trm0047m!!!COM: Leoš [Leo Eugen] Janáček
 !!!OTL: [R130_Jan-w33p13m63-71]
 !!!OMV:
 !!!example:
@@ -18,7 +27,7 @@
 *	*	*	*	*	*	*	*	*	*	*	*	*	*	*^	*	*	*	*	*	*	*	*	*	*	*
 *	*	*	*	*	*	*	*	*	*	*tremolo	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*
 !	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:a:t=a2	!	!LO:TX:a:t=a2	!	!LO:TX:a:t=a2	!
-4.An 4.Bn 4.d#X	.	4.e-	[4.cc-Xt	ff	[4.ccc-Xt	ff	[4.ccc-Xt	ff	4.ff	32E-XLLL	mf	4.E- 4.A- 4.c	< [	4.e-X	4.e-	< [	[4.BB-- [4.C-X	ff	[4.E-	ff	[4.bbXt	ff	[4.bbnt	ff	[4.bbnt	ff
+4.An 4.Bn 4.d#X	.	4.e-	[4.cc-XTT	ff	[4.ccc-XTT	ff	[4.ccc-XTT	ff	4.ff	32E-XLLL	mf	4.E- 4.A- 4.c	< [	4.e-X	4.e-	< [	[4.BB-- [4.C-X	ff	[4.E-	ff	[4.bbXTT	ff	[4.bbnTT	ff	[4.bbnyTT	ff
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
@@ -32,7 +41,7 @@
 .	.	.	.	.	.	.	.	.	.	32E-XJJJ	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 *	*	*	*	*	*	*	*	*	*	*	*	*	*	*v	*v	*	*	*	*	*	*	*	*	*	*	*
 =2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2	=2
-8%3r	.	8%3r	4.cc-_	<	4.ccc-_	<	4.ccc-_	<	8%3r	32E-XLLL	.	8%3r	.	8%3r	.	4.BB_ 4.C-_	.	4.E-_	.	4.bb_	.	4.bb_	.	4.bb_	.
+8%3r	.	8%3r	4.cc-_TTT	<	4.ccc-_TTT	<	4.ccc-_TTT	<	8%3r	32E-XLLL	.	8%3r	.	8%3r	.	4.BB_ 4.C-_	.	4.E-_	.	4.bb_TTT	.	4.bb_TTT	.	4.bb_TTT	.
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
@@ -45,7 +54,7 @@
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	.	.	32E-XJJJ	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 =3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3	=3
-8%3r	.	8%3r	4.cc-]	[	4.ccc-]	[	4.ccc-]	[	8%3r	32E-XLLL	<	8%3r	.	8%3r	.	4.BB_ 4.C-_	.	4.E-_	.	4.bb_	.	4.bb_	.	4.bb_	.
+8%3r	.	8%3r	4.cc-]TTT	[	4.ccc-]TTT	[	4.ccc-]TTT	[	8%3r	32E-XLLL	<	8%3r	.	8%3r	.	4.BB_ 4.C-_	.	4.E-_	.	4.bbTTT_	.	4.bb_TTT	.	4.bb_TTT	.
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
@@ -60,12 +69,12 @@
 =4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4	=4
 *k[]	*	*k[]	*k[]	*	*k[]	*	*k[]	*	*k[]	*k[]	*	*k[]	*	*k[b-]	*	*k[]	*	*k[b-e-]	*	*k[b-e-]	*	*k[]	*	*k[]	*
 *C:	*	*C:	*C:	*	*C:	*	*C:	*	*C:	*C:	*	*C:	*	*F:	*	*C:	*	*B-:	*	*B-:	*	*C:	*	*C:	*
-!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:t=[quarter]=120	!
-!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:a:t=rit.	!
+!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:t=[quarter.]=84	!
+!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!
 !	!	!	!	!	!	!	!	!	!LO:TX:t=[quarter]=120	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:a:t=rit.	!
 !	!	!	!	!	!	!	!	!	!LO:TX:a:B:t=a tempo	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:a:B:t=a tempo	!
 !	!	!	!	!	!	!	!	!	!LO:TX:a:B:t=Vivo	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:a:B:t=Vivo	!
-8%3r	.	8%3r	4.bt	.	4.bt	.	4.bbt	.	8%3r	32E-XLLL	[	8%3r	.	8%3r	.	4.AA_ [4.BB	.	4.E-_	< [	4.bb_	< [	4.bb_	< [	4.bb_	< [
+8%3r	.	8%3r	4.bTT	.	4.bTT	.	4.bbTT	.	8%3r	32E-XLLL	[	8%3r	.	8%3r	.	4.AA_ [4.BB	.	4.E-_	< [	4.bb_TTT	< [	4.bb_TTT	< [	4.bb_TTT	< ]
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	.	.	.	.	.	.	.	32E-X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
@@ -79,7 +88,7 @@
 .	.	.	.	.	.	.	.	.	.	32E-XJJJ	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 *	*	*	*	*	*	*	*	*	*	*Xtremolo	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*
 =5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||	=5||
-!	!	!	!	!	!	!	!	!	!LO:TX:t=[quarter-dot]=84	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:t=[quarter-dot]=84	!
+!	!	!	!	!	!	!	!	!	!LO:TX:t=[quarter-dot]=84	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!
 8%3r	.	8%3r	64%3gLLL	.	64%3gLLL	.	64%3ggLLL	.	8%3r	64%3BBnLLL	f <	8%3r	.	8%3r	.	4.AA_ [4.BB	.	4.E-_	.	(16%3bbL_	.	4.bb_	.	(16%3bbL_	.
 .	.	.	64%3a	.	64%3a	.	64%3aa	.	.	64%3BB	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 .	.	.	64%3b	.	64%3b	.	64%3bb	.	.	64%3BB	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
@@ -92,7 +101,7 @@
 *	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*	*^	*	*	*	*	*	*	*	*	*
 !	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:a:t=Solo	!
 !LO:TX:a:t=pizz.	!	!LO:TX:a:t=arco	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!	!LO:TX:b:i:t=stacc.	!
-4G	f	16%3r	8%3r	.	8%3r	.	8%3r	.	8%3r	8BBn^^	.	8%3r	.	8%3r	.	4BB^^]	[4.GG^^	.	8E-^^]	.	8eee-^^)	.	8bb^^]	.	8ddd#XL	.
+4G	f	16%3r	8%3r	.	8%3r	.	8%3r	.	8%3r	8BBn^^	.	8%3r	.	8%3r	.	4BB^^]	[4.GG^^	.	8E-^^]	.	8eeenX-^^)	.	8bb^^]	.	8ddd#XL	.
 .	.	.	.	.	.	.	.	.	.	8r	.	.	.	.	.	.	.	.	8r	.	8r	.	8r	.	8bb	.
 .	.	16%3BB 16%3D#X	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.	.
 8r	.	.	.	.	.	.	.	.	.	8r	.	.	.	.	.	8r	.	.	8r	.	8r	.	8r	.	8ddd#J	.
@@ -139,3 +148,452 @@
 !!!excerpt-end-time:
 !!!EEV: 2020/07/28
 !!!ONB: Converted from MusicXML on 2020/07/28
+!!!SCA: Trm0047m!!!COM: Leoš [Leo Eugen] Janáček
+!!!OTL: [R129_Jan-w30p11m124-127]
+!!!OMV:
+!!!example:
+!!!work:
+**kern	**kern	**dynam	**kern	**dynam
+*grp:A	*grp:B	*grp:B	*grp:A	*grp:A
+*part2	*part2	*part2	*part1	*part1
+*staff3	*staff2	*	*staff1	*
+*I"Piano	*	*	*I"Violoncello	*
+*I'Pno.	*	*	*I'Vc.	*
+*clefF4	*clefG2	*	*clefF4	*
+*k[f#c#g#]	*k[f#c#g#]	*	*k[f#c#g#]	*
+*A:	*A:	*	*A:	*
+*M2/8	*M2/8	*	*M2/8	*
+=1	=1	=1	=1	=1
+*^	*	*	*	*
+!	!	!	!	!LO:TX:t=[eighth]=84	!
+!	!	!LO:TX:b:t=[f]	!	!LO:TX:b:t=[mf cresc.]	!
+(8.GnL	24EE	4r	f	24r	.
+*	*	*	*	*Xtuplet	*
+.	24ELL	.	.	(24BB'LL	<
+.	24EJJ 24G#X	.	.	24BB'JJ 24E	.
+.	8r	.	.	24BB'LL 24E	.
+!	!	!	!	!LO:TX:b:i:t=espress.	!
+.	.	.	.	24BB'JJ 24E)	[
+16BJk	.	.	.	.	.
+.	.	.	.	24gn	.
+=2	=2	=2	=2	=2	=2
+!	!	!	!	!LO:TX:b:i:t=cresc.	!
+24EE	8ryy	(64ff#XLLLL	.	(16aLL	f
+.	.	64ee	.	.	.
+.	.	64b	.	.	.
+24E'LL	.	.	.	.	.
+.	.	64gnJJJ	.	.	.
+.	.	64cc#XLLL	.	16gn	.
+.	.	64b	.	.	.
+24E'JJ 24Gn	.	.	.	.	.
+.	.	64g	.	.	.
+.	.	64eJJJJ)	.	.	.
+24BB	24BB	8r	.	16f#X	.
+24E'LL	24ryy	.	.	.	.
+.	.	.	.	16BJJ)	.
+24E'JJ 24G	24ryy	.	.	.	.
+=3	=3	=3	=3	=3	=3
+24C#X	24C#	8r	.	(8.eL	.
+24E'LL	24ryy	.	.	.	.
+24E'JJ 24Gn	24ryy	.	.	.	.
+24BB	24BB	8r	.	.	.
+24E'LL	24ryy	.	.	.	.
+.	.	.	.	16gnJk)	.
+24E'JJ 24G	24ryy	.	.	.	.
+=4	=4	=4	=4	=4	=4
+24EE	24EE	(64ff#XLLLL	.	(16aLL	.
+.	.	64ee	.	.	.
+.	.	64b	.	.	.
+24E'LL	24ryy	.	.	.	.
+.	.	64gnJJJ	.	.	.
+.	.	64cc#XLLL	.	16gn	.
+.	.	64b	.	.	.
+24E'JJ 24Gn	24ryy	.	.	.	.
+.	.	64g	.	.	.
+.	.	64eJJJJ)	.	.	.
+24BB	24BB	8r	.	16f#X	.
+24E'LL	24ryy	.	.	.	.
+.	.	.	.	16BJJ)	.
+24E'JJ 24G	24ryy	.	.	.	.
+*v	*v	*	*	*	*
+=	=	=	=	=
+*-	*-	*-	*-	*-
+!!!system-decoration: s1[({(s2,s3)})]
+!!!CDT:
+!!!CBL:
+!!!CDL:
+!!!CNT:
+!!!AGN:
+!!!MCN:
+!!!MDT:
+!!!MGN:
+!!!MLC:
+!!!MPD:
+!!!MPN:
+!!!ODT:
+!!!PDT:
+!!!excerpt-start-measure:
+!!!excerpt-end-measure:
+!!!excerpt-start-time:
+!!!excerpt-end-time:
+!!!EEV: 2020/07/28
+!!!ONB: Converted from MusicXML on 2020/07/28
+!!!rime: 47
+!!!original-voices:	3
+!!!extant-voices: 3
+!!!complete: Y
+!!!final: G
+**kern	**text	**kern	**text	**kern	**text
+*staff3	*staff3	*staff2	*staff2	*staff1	*staff1
+*Ivox	*	*Ivox	*	*Ivox	*
+*I"Basso	*	*I"Tenore	*	*I"Canto	*
+*I'B	*	*I'T	*	*I'C	*
+*oclefC3	*	*oclefC2	*	*oclefG2	*
+*clefGv2	*	*clefG2	*	*clefG2	*
+*k[]	*	*k[]	*	*k[]	*
+*omet(C)	*	*omet(C)	*	*omet(C)	*
+*M4/2	*	*M4/2	*	*M4/2	*
+=1	=1	=1	=1	=1	=1
+0r	.	0r	.	1g	Non
+.	.	.	.	2a	è
+.	.	.	.	2b	que-
+=2	=2	=2	=2	=2	=2
+0r	.	1r	.	2cc	-sta
+.	.	.	.	2dd	la
+.	.	1c	Non	2ee	ma-
+.	.	.	.	2ee	-no
+=3	=3	=3	=3	=3	=3
+0r	.	2d	è	4r	.
+.	.	.	.	4dd	Che
+.	.	2e	que-	4cc	tan-
+.	.	.	.	4b	-t'e
+.	.	2f	-sta	4a	sì
+.	.	.	.	4a	mor-
+.	.	2g	la	2b	-ta-
+=4	=4	=4	=4	=4	=4
+1r	.	2a	ma-	4cc#X	.
+.	.	.	.	2dd	.
+.	.	2a	-no	.	.
+.	.	.	.	4cc#X	.
+1G	Non	2r	.	2dd	-li
+.	.	2g	Che	4.b	A-
+.	.	.	.	8b	-ven-
+=5	=5	=5	=5	=5	=5
+2A	è	4f	tan-	4ccni	-tò
+.	.	4e	-t'e	8ccL	nel
+.	.	.	.	8ccJ	mio
+2B	que-	4d	sì	4dd	cor
+.	.	4d	mor-	4gg	fiam-
+2c	-sta	2e	-ta-	8eeL	-mel-
+.	.	.	.	8dd	.
+.	.	.	.	8cc	.
+.	.	.	.	8bJ	.
+2d	la	2f	.	4a	.
+.	.	.	.	4a	-le e
+=6	=6	=6	=6	=6	=6
+2e	ma-	4gni	.	4.cc	stra-
+.	.	2a	.	.	.
+.	.	.	.	16bLL	.
+.	.	.	.	16aJJ	.
+2e	-no	.	.	2b	.
+.	.	4g#X	.	.	.
+2r	.	2a	-li	2a	-li?
+2d	Che	4.f	A-	4ff	Ec-
+.	.	.	.	8ffL	-co
+.	.	8f	-ven-	8ffJ	che
+=7	=7	=7	=7	=7	=7
+4c	tan-	4gni	-tò	4ee	pur
+4B	-t'e	8gL	nel	4dd	si
+.	.	8gJ	mio	.	.
+4A	sì	4a	cor	4cc	tro-
+4A	mor-	4cc	fiam-	4a	-va
+2G	-ta-	8bL	-mel-	8r	.
+.	.	8a	.	8bL	Fra
+.	.	8g	.	8b	le
+.	.	8fJ	.	8bJ	mie
+2A	.	4e	.	4cc	man
+.	.	4e	-le e	4cc	ri-
+=8	=8	=8	=8	=8	=8
+!!pagebreak:original
+4B	.	4.g	stra-	1dd	-stret-
+2c	.	.	.	.	.
+.	.	16fLL	.	.	.
+.	.	16eJJ	.	.	.
+.	.	2d	.	.	.
+4B	.	.	.	.	.
+2c	-li	2e	-li?	2g	-ta,
+4.c	A-	4cc	Ec-	8r	.
+.	.	.	.	8eeL	<Fra
+.	.	8ccL	-co	8ee	le
+8c	-ven-	8ccJ	che	8eeJ	mie
+=9	=9	=9	=9	=9	=9
+4d	-tò	4b-X	pur	4ff	man
+8dL	nel	4a	si	4ff	ri-
+8dJ	mio	.	.	.	.
+4e	cor	4g	tro-	4gg	-stret-
+4c	fiam-	4e	-va	4gg	-ta,>
+8cL	-mel-	8r	.	4ee	Ec-
+8B	.	8eL	Fra	.	.
+8A	.	8e	le	8eeL	-co
+8GJ	.	8eJ	mie	8eeJ	che
+4F	.	4f	man	4dd	pur
+4A	-le e	4f	ri-	4cc	si
+=10	=10	=10	=10	=10	=10
+2G	stra-	1g	-stret-	4b	tro-
+.	.	.	.	4b	-va
+2G	-li?	.	.	8r	.
+.	.	.	.	8bL	Fra
+.	.	.	.	8b	le
+.	.	.	.	8bJ	mie
+2r	.	2c	-ta,	4cc	man
+.	.	.	.	4cc	ri-
+4g	Ec-	2r	.	4dd	-stret-
+8gL	-co	.	.	4dd	-ta,
+8gJ	che	.	.	.	.
+=11	=11	=11	=11	=11	=11
+4f	pur	4cc	Ec-	2r	.
+4e	si	8ccL	-co	.	.
+.	.	8ccJ	che	.	.
+4d	tro-	4b-X	pur	4ff	Ec-
+4d	-va	4a	si	8ffL	-co
+.	.	.	.	8ffJ	che
+8r	.	4g	tro-	4ee	pur
+8eL	Fra	.	.	.	.
+8e	le	4g	-va	4ee	si
+8eJ	mie	.	.	.	.
+4f	man	8r	.	4dd	tro-
+.	.	8aL	Fra	.	.
+4f	ri-	8a	le	4cc	-va
+.	.	8aJ	mie	.	.
+=12	=12	=12	=12	=12	=12
+4g	-stret-	4bni	man	8r	.
+.	.	.	.	8ddL	Fra
+4g	-ta,	4b	ri-	8dd	le
+.	.	.	.	8ddJ	mie
+8r	.	4cc	-stret-	4ee	man
+8eL	Fra	.	.	.	.
+8e	le	4cc	-ta,	4ee	ri-
+8eJ	mie	.	.	.	.
+4f	man	8r	.	1dd	-stret-
+.	.	8aL	Fra	.	.
+4f	ri-	8a	le	.	.
+.	.	8aJ	mie	.	.
+2g	-stret-	4b	man	.	.
+.	.	4b	ri-	.	.
+=13	=13	=13	=13	=13	=13
+1c	-ta,	2cc	-stret-	2cc	-ta,
+.	.	2cc	-ta,	1g	Né
+1c	Né	2r	.	.	.
+.	.	2e	Né	2a	for-
+=14	=14	=14	=14	=14	=14
+!!pagebreak:original
+2d	for-	2f#X	for-	2a	-za
+2d	-za	2f#i	-za	2b	d'ar-
+2e	d'ar-	2g	d'ar-	[1b	-te
+2e	-te,	2g	-te	.	.
+=15	=15	=15	=15	=15	=15
+1e	Né	4r	.	2b]	.
+.	.	8gL	per	.	.
+.	.	8aJ	fug-	.	.
+.	.	4.b	-gir	2r	.
+.	.	8cc	le	.	.
+2f	for-	4dd	gio-	4r	.
+.	.	4dd	-va,	8ffL	per
+.	.	.	.	8eeJ	fug-
+2f	-za	2r	.	4.dd	-gir
+.	.	.	.	8cc	le
+=16	=16	=16	=16	=16	=16
+1g	d'ar-	4r	.	4b	gio-
+.	.	8gL	<per	4b	-va,
+.	.	8aJ	fug-	.	.
+.	.	4.b	-gir	4r	.
+.	.	.	.	8gL	<per
+.	.	8cc	le	8aJ	fug-
+2g	-te	4dd	gio-	4.b	-gir
+.	.	4dd	-va,>	.	.
+.	.	.	.	8cc	le
+4r	.	2r	.	4dd	gio-
+8gL	per	.	.	4dd	-va,>
+8fJ	fug-	.	.	.	.
+=17	=17	=17	=17	=17	=17
+4.e	-gir	4r	.	1g	Né
+.	.	8gL	per	.	.
+8d	le	8fJ	fug-	.	.
+4c	gio-	4.e	-gir	.	.
+4c	-va,	.	.	.	.
+.	.	8d	le	.	.
+4r	.	4c	gio-	2a	for-
+8AL	<per	4c	-va,	.	.
+8GJ	fug-	.	.	.	.
+4.F	-gir	2c	Né	2a	-za
+8E	le	.	.	.	.
+=18	=18	=18	=18	=18	=18
+4D	gio-	4d	for-	2b	d'ar-
+4D	-va,>	4d	-za	.	.
+4r	.	2d	d'ar-	4b	-te
+8GL	per	.	.	8bL	per
+8FJ	fug-	.	.	8aJ	fug-
+2E	-gir	4e	-te	2g	-gir,
+.	.	8gL	per	.	.
+.	.	8fJ	fug-	.	.
+2E	le	2e	-gir,	4r	.
+.	.	.	.	8eeL	<per
+.	.	.	.	8ddJ	fug-
+=19	=19	=19	=19	=19	=19
+1F	gio-	4r	.	2cc	-gir,>
+.	.	8aL	per	.	.
+.	.	8gJ	fug-	.	.
+.	.	4f	-gir,	4r	.
+.	.	8fL	per	8ddL	per
+.	.	8eJ	fug-	8ccJ	fug-
+1G	-va,	4d	-gir	4b	-gir
+.	.	4e	le	4cc	le
+.	.	2d	gio-	2b	gio-
+=20	=20	=20	=20	=20	=20
+!!pagebreak:original
+1g	Né	1c	-va,	1cc	-va,
+2e	tien	2r	.	1gg	Né
+2c	fa-	[2g	Né	.	.
+=21	=21	=21	=21	=21	=21
+2c	-ce o	4g]	.	2ee	tien
+.	.	2e	tien	.	.
+2A	sa-	.	.	2cc	fa-
+.	.	2e	fa-	.	.
+8AL	-et-	.	.	2cc	-ce o
+8G	.	.	.	.	.
+8A	.	2c	-ce o	.	.
+8BJ	.	.	.	.	.
+8cL	.	.	.	2a	sa-
+8B	.	.	.	.	.
+8c	.	4A	sa-	.	.
+8dJ	.	.	.	.	.
+=22	=22	=22	=22	=22	=22
+1e	.	8cL	-et-	8gL	-et-
+.	.	8d	.	8f	.
+.	.	8e	.	8g	.
+.	.	8fJ	.	8aJ	.
+.	.	8gL	.	8bL	.
+.	.	8f	.	8a	.
+.	.	8g	.	8b	.
+.	.	8aJ	.	8ccJ	.
+2d	-ta	4b	.	2.dd	.
+.	.	4a	-ta	.	.
+4r	.	4r	.	.	.
+8dL	Che	8fL	Che	4a	-ta
+8eJ	da	8gJ	da	.	.
+=23	=23	=23	=23	=23	=23
+2f	me	2a	me	4r	.
+.	.	.	.	8aL	Che
+.	.	.	.	8bJ	da
+4r	.	2r	.	2cc	me
+8eL	la	.	.	.	.
+8fJ	di-	.	.	.	.
+1g	-fen-	4r	.	4r	.
+.	.	8gL	la	8bL	la
+.	.	8aJ	di-	8ccJ	di-
+.	.	2b	-fen-	2dd	-fen-
+=24	=24	=24	=24	=24	=24
+1c	-da.	1cc	-da.	1ee	-da.
+4g	Giu-	4b	Giu-	4dd	Giu-
+4g	-st'è	4b	-st'è	4dd	-st'è
+2g	ben	2b	ben	2dd	ben
+=25	=25	=25	=25	=25	=25
+4g	ch'io	4b	ch'io	4dd	ch'io
+4a	ne	4a	ne	4cc	ne
+2e	pren-	2g#X	pren-	2b	pren-
+4e	-da,	4g#i	-da,	4b	-da,
+4a	A-	4a	A-	4cc	A-
+4g	-mor,	4b	-mor,	4dd	-mor,
+4e	qual-	4cc	qual-	4ee	qual-
+=26	=26	=26	=26	=26	=26
+4f	-che	4a	-che	4cc	-che
+4d	ven-	4b	ven-	4dd	ven-
+2c	-det-	2cc	-det-	2ee	-det-
+4c	-ta,	4cc	-ta,	4ee	-ta,
+4e	A-	4g	A-	4b	A-
+4d	-mor,	4f#X	-mor,	4dd	-mor,
+4B	qual-	4g	qual-	4dd	qual-
+=27	=27	=27	=27	=27	=27
+4c	-che	4e	-che	4cc	-che
+4A	ven-	4f#i	ven-	4cc	ven-
+2G	-det-	2g	-det-	2b	-det-
+1G	-ta,	1g	-ta,	1b	-ta,
+=28	=28	=28	=28	=28	=28
+1c	E	2r	.	2r	.
+.	.	2.cc	E	2.ee	E
+2g	se	.	.	.	.
+.	.	2b	se	2dd	se
+2a	pia-	.	.	.	.
+.	.	[4a	pia-	[4cc	pia-
+=29	=29	=29	=29	=29	=29
+!!pagebreak:original
+2e	-ghe	4a]	.	4cc]	.
+.	.	2g	-ghe	2b	-ghe
+2f	mi	.	.	.	.
+.	.	4f	mi	4a	mi
+1c	diè,	1e	diè	2g	diè
+.	.	.	.	4ee	ba-
+.	.	.	.	8eeL	-ci
+.	.	.	.	8ddJ	le
+=30	=30	=30	=30	=30	=30
+2r	.	4a	ba-	4cc	ren-
+.	.	8aL	-ci	4cc	-da,
+.	.	8bJ	le	.	.
+2a	E	4cc	ren-	4ee	ba-
+.	.	4cc	-da,	8eeL	-ci
+.	.	.	.	8ffJ	le
+2g	se	4b	ba-	4gg	ren-
+.	.	8bL	-ci	4gg	-da,
+.	.	8bJ	le	.	.
+2f	pia-	4cc	ren-	4cc	ba-
+.	.	4a	-da,	8ccL	-ci
+.	.	.	.	8ddJ	le
+=31	=31	=31	=31	=31	=31
+2e	-ghe	4b	<ba-	4ee	ren-
+.	.	8bL	-ci	4ee	-da,
+.	.	8ccJ	le	.	.
+2d	mi	4dd	ren-	4a	<ba-
+.	.	4dd	-da,>	8aL	-ci
+.	.	.	.	8bJ	le
+2c	diè,	4g	<ba-	4cc	ren-
+.	.	8gL	-ci	4cc	-da,>
+.	.	8fJ	le	.	.
+4c	ba-	4e	ren-	4ee	<ba-
+8cL	-ci	4e	-da,>	8eeL	-ci
+8BJ	le	.	.	8ddJ	le
+=32	=32	=32	=32	=32	=32
+4A	ren-	4a	<ba-	4cc	ren-
+4A	-da,	8aL	-ci	4cc	-da,>
+.	.	8gJ	le	.	.
+2d	ba-	4f	ren-	4dd	ba-
+.	.	4a	-da,>	8ccL	-ci
+.	.	.	.	8bJ	le
+2d	-ci,	4dd	ba-	4a	ren-
+.	.	8ccL	-ci	4a	-da,
+.	.	8bJ	le	.	.
+2d	ba-	4a	ren-	4dd	<ba-
+.	.	4a	-da,	8ccL	-ci
+.	.	.	.	8bJ	le
+=33	=33	=33	=33	=33	=33
+2d	-ci	4dd	<ba-	4a	ren-
+.	.	8ccL	-ci	4a	-da,>
+.	.	8bJ	le	.	.
+2d	le	4.a	ren-	4dd	<ba-
+.	.	.	.	8ccL	-ci
+.	.	8g	.	8bJ	le
+1d	ren-	4.f#X	.	4.a	ren-
+.	.	8e	.	8g	.
+.	.	2f#X	.	2a	.
+=34	=34	=34	=34	=34	=34
+0Gl	-da.	0gl	-da.>	0bl	-da.>
+==	==	==	==	==	==
+*-	*-	*-	*-	*-	*-
+!!!system-decoration: [*]
+!!!RDF**kern: i = editorial accidental
+!!!RDF**kern: l = terminal long
+!!!ENC: Emiliano Ricciardi
+!!!END: 2013
+!!!EED: Ricciardi, Emiliano
+!!!EEV: 2017/10/16
+!!!YEC: Copyright 2013 Emiliano Ricciardi, All Rights Reserved
+!!!ONB: Translated from MusicXML on 2014/11/15 and edited by Craig Stuart Sapp


### PR DESCRIPTION
not showing measure number or rehearsal mark at beginning
added trill special symbols
extended trill lines at beginning
need to change tuplet numbers to match example - command does not seem to be workign
some crescendos are showing as parentheses, command is not working to fix them
forced show natural accidental in Bb clarinet part
positioning of some slurs needs to be adjusted
trying to change cresc. text to actual crescendos but command not working
tried to add hanging ties but command not working
need to show rit. above string system
fixed tempo marking at top
fixed two rits at top (two rits. showing)
fixed extra tempo marking
staff spacing needs to be adjusted to prevent clashing