### PR TITLE
Update R295_Rav-w23p20h22m1-4.krn

### DIFF
--- a/kern/R295_Rav-w23p20h22m1-4.krn
+++ b/kern/R295_Rav-w23p20h22m1-4.krn
@@ -18,10 +18,10 @@
 *	*^	*	*	*	*	*	*	*
 !	!	!	!LO:TX:b:t=[pp]	!	!	!LO:TX:a:t=arco	!	!	!
 4r	2.AAA 2.AA	4ryy	4r	4ryy	.	8ee'`L	pp	8eeee'`L	pp
-!	!	!	!	!	!	!	!	!LO:TX:t=[quarter]=192	!
+!	!	!	!	!	!	!	!	!LO:TX:t=[[quarter]=192]	!
 .	.	.	.	.	.	8ee'`	.	8eeee'`	.
 !	!	!	!LO:TX:b:i:t=cresc. poco a poco	!	!	!LO:TX:b:i:t=cresc. poco a poco	!	!LO:TX:b:i:t=cresc. poco a poco	!
-2AA	.	4E\	(4E	2C#	< [	8dd'	.	8dddd'	.
+2AA	.	4E\(	(4E	2C#	< [	8dd'	.	8dddd'	.
 .	.	.	.	.	.	8ee'`J	.	8eeee'`J	.
 .	.	4Fn\	4Fn	.	.	8a'`L	.	8aaa'`L	.
 .	.	.	.	.	.	8a'`	.	8aaa'`	.
@@ -37,14 +37,14 @@
 *	*v	*v	*	*	*	*	*
 *X8ba	*	*	*	*	*	*
 *^	*^	*	*	*	*	*
-4AA]	4G	4E-X 4G)	4Cn	]	8a'L	.	8aaa'L	.
+4AA])	4G	4E-X 4G)	4Cn	]	8a'L	.	8aaa'L	.
 .	.	.	.	.	8a'	.	8aaa'	.
 *	*	*v	*v	*	*	*	*	*
 =3	=3	=3	=3	=3	=3	=3	=3
 *	*^	*	*	*	*	*	*
 4r	2.AAA 2.AA	4ryy	4r	.	8gn'	.	8gggn'	.
 .	.	.	.	.	8a'J	.	8aaa'J	.
-2F#	.	4Cn\	(4A 4cn	<	8d'L	.	8ddd'L	.
+2F#(	.	4Cn\	(4A 4cn	<	8d'L	.	8ddd'L	.
 .	.	.	.	.	8d'	.	8ddd'	.
 .	.	4D\	4d	[	8fn'	.	8fffn'	.
 .	.	.	.	.	8g'J	.	8ggg'J	.
@@ -53,13 +53,13 @@
 *	*	*^	*	*	*	*	*
 2F#X	12FnL	12fnL	2A	>	8a'L	.	8aaa'L	.
 .	12E-X	12e-X	.	.	.	.	.	.
-*	*	*	*	*	*	*	*X8va	*
+*	*	*	*	*	*	*	*	*
 .	.	.	.	.	8a'J	.	8aaa'J	.
 .	12DJ	12dJ	.	.	.	.	.	.
-*	*	*	*	*	*clefF4	*	*	*
+*	*	*	*	*	*clefF4	*	*X8va	*
 .	4Cn	4cn	.	.	8d'L	.	8ddd'L	.
 .	.	.	.	.	8d'J	.	8ddd'J	.
-4F#X	4D	4d)	4A	]	8cn'L	.	8cccn'L	.
+4F#X)	4D	4d)	4A	]	8cn'L	.	8cccn'L	.
 .	.	.	.	.	8d'J	.	8ddd'J	.
 *v	*v	*	*	*	*	*	*	*
 *	*v	*v	*	*	*	*	*


### PR DESCRIPTION
rehearsal mark and measure number need to be added at beginning
added brackets around tempo marking, beams need to be fixed in violin and cello parts (J and L commands are not working)
changed 8va ending in vln 1, crescendo in 1st measure of piano part is showing as “cresc.” (Command not working to fix it)
8ba needs to be moved to first note in bass piano stave (command not working)
8ba command is not applying to all notes of the piano bass stave
stem directions need to be fixe for piano bass stave (cant figure out how to do this)
slur in bass piano stave needs to be moved to above the staff
8ba needs to be extended in bass piano stave to end of 2nd measure
added slur in last 2 measures of piano bass stave
hanging tie needs to be added to first note in bass piano stave (command not working)
3rd measure of piano treble stave - note stem directions need to be adjusted to show 2 seperate layers